### PR TITLE
Protocol bug fixed: On init, protocol was getting split off and not passed to subsequent page objects

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -79,8 +79,16 @@ PageObject = Class.extend({
   },
 
   _initProtocol: function() {
-    var address = this._config.address || '',
-        addrArr = address.split('://');
+    var address,
+        addrArr;
+
+    if (this._config.protocol && this._config.address) {
+      return;
+    }
+
+    address = this._config.address || '';
+
+    addrArr = address.split('://');
 
     if (addrArr.length === 1) {
       // Protocol had not been defined


### PR DESCRIPTION
Bug fix:
Protocol split from address on init, making subsequent page builds always evaluate to default http. Now checks if a protocol is stored first and evaluates accordingly.